### PR TITLE
Validate that an attachment exists

### DIFF
--- a/src/main/java/com/ch/conversion/builders/FormJsonBuilder.java
+++ b/src/main/java/com/ch/conversion/builders/FormJsonBuilder.java
@@ -1,10 +1,10 @@
 package com.ch.conversion.builders;
 
-
 import com.ch.application.FormServiceConstants;
 import com.ch.conversion.config.ITransformConfig;
 import com.ch.conversion.helpers.JsonHelper;
 import com.ch.conversion.validation.XmlValidatorImpl;
+import com.ch.exception.MissingRequiredDataException;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -41,6 +41,10 @@ public class FormJsonBuilder {
     this.form = helper.getObjectFromJson(form, "parent json object (form body part)", config.getFormPropertyNameIn());
     this.attachments = helper.getArrayFromJson(form, "parent json object (form body part)",
       config.getAttachmentsPropertyNameIn());
+    
+    if (attachments.length() == 0) {
+      throw new MissingRequiredDataException(config.getAttachmentsPropertyNameIn() + " length is 0", "(form body part)");
+    }
 
     if (presenterAccountNumber != null) {
       addAccountNumber(presenterAccountNumber);

--- a/src/test/java/com/ch/conversion/builders/FormJsonBuilderTest.java
+++ b/src/test/java/com/ch/conversion/builders/FormJsonBuilderTest.java
@@ -10,14 +10,11 @@ import com.ch.conversion.config.TransformConfig;
 import com.ch.exception.MissingRequiredDataException;
 import com.ch.helpers.TestHelper;
 import com.ch.model.PresenterAuthResponse;
-import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
-
-import java.io.IOException;
 
 /**
  * Created by elliott.jenkins on 31/03/2016.
@@ -49,6 +46,14 @@ public class FormJsonBuilderTest extends TestHelper {
         FormJsonBuilder builder = new FormJsonBuilder(config, valid, valid, TEST_PRESENTER_ACCOUNT);
         builder.getJson();
     }
+    
+    @Test(expected = MissingRequiredDataException.class)
+    public void throwsMissingRequiredDataExceptionWithValidJsonMissingAttachemnts() throws Exception {
+        String validPackage = getStringFromFile(PACKAGE_JSON_PATH);
+        String validForm = getStringFromFile(FORM_ALL_JSON_MISSING_ATTACHMENT);
+        FormJsonBuilder builder = new FormJsonBuilder(config, validPackage, validForm, TEST_PRESENTER_ACCOUNT);
+        builder.getJson();
+    }
 
     @Test
     public void createJSONObjectForValidJson() throws Exception {
@@ -66,7 +71,6 @@ public class FormJsonBuilderTest extends TestHelper {
           .get("accountNumber")));
     }
 
-
     private FormJsonBuilder getValidFormJsonBuilder() throws Exception {
         // valid package data
         String package_string = getStringFromFile(PACKAGE_JSON_PATH);
@@ -75,6 +79,4 @@ public class FormJsonBuilderTest extends TestHelper {
         // builder
         return new FormJsonBuilder(config, package_string, form_string, TEST_PRESENTER_ACCOUNT);
     }
-
-
 }

--- a/src/test/java/com/ch/helpers/TestHelper.java
+++ b/src/test/java/com/ch/helpers/TestHelper.java
@@ -38,6 +38,7 @@ public class TestHelper {
   protected static final String FORM_JSON_PATH = "json/form.json";
   protected static final String FORM_ALL_JSON_PATH = "json/form_all.json";
   protected static final String FORM_ALL_JSON_NO_ACC_NUMBER_PATH = "json/form_no_account_number.json";
+  protected static final String FORM_ALL_JSON_MISSING_ATTACHMENT = "json/form_missing_attachment.json";
   protected static final String INVALID_FORM_JSON_PATH = "json/invalid_form_all.json";
 
   protected static final String META_PATH = "json/meta.json";

--- a/src/test/resources/json/form_missing_attachment.json
+++ b/src/test/resources/json/form_missing_attachment.json
@@ -1,0 +1,48 @@
+{
+  "metadata": {
+    "type": "DS01",
+    "version": "1",
+    "submissionReference": "038-496949"
+  },
+  "formdata": {
+    "filingDetails": {
+      "authoriser": "director",
+      "signDate": "2016-03-31",
+      "receiptDate": "2016-03-31",
+      "presenterDocumentReference": "DS0009",
+      "barcode": "J53W9DA1",
+      "presenterDetails": {
+        "presenterName": "Steve Bowen",
+        "presenterAccountNumber": "12345678901",
+        "presenterEmailIn": "sbowen@companieshouse.gov.uk",
+        "presenterEmailOut": "sbowen@companieshouse.gov.uk",
+        "presenterAddressLine1": "Companies House",
+        "presenterAddressLine2": "Crown Way",
+        "presenterAddressPostTown": "Cardiff",
+        "presenterAddressCountry": "Wales",
+        "presenterAddressPostCode": "CF3 4UZ"
+      },
+      "payment": {
+        "paymentMethod": "account",
+        "accountNumber": "00599998000"
+      }
+    },
+    "corporateBody": {
+      "incorporationNumber": "09450005",
+      "corporateBodyName": "LIVERPOOL GIRL GEEKS LTD",
+      "officers": {
+        "officer": {
+          "personName": {
+            "titleOther": "MR",
+            "forename": "MICHAEL",
+            "middlenames": "COSMAS",
+            "surname": "MICHAEL"
+          },
+          "signDate": "2016-03-31"
+        }
+      }
+    }
+  },
+  "attachments": [
+  ]
+}


### PR DESCRIPTION
Update the forms enablement API microservice so that it throws an error if it receives a submission that has no attachments. It previously only checked for the presence of an "attachments" element and not that there were sub "attachment" elements.

SUP-298

### Type of change

* [X] Bug fix
* [ ] New feature
* [ ] Breaking change

### Pull request checklist

* [X] I have added unit tests for new code that I have added
* [X] I have added/updated functional tests where appropriate
* [X] The code follows our [coding standards](https://github.com/companieshouse/styleguides/blob/master/java.md)