### PR TITLE
Add inital confirmpaid endpoint

### DIFF
--- a/src/main/java/com/ch/application/FormsServiceApplication.java
+++ b/src/main/java/com/ch/application/FormsServiceApplication.java
@@ -25,6 +25,7 @@ import com.ch.helpers.ClientHelper;
 import com.ch.helpers.MongoHelper;
 import com.ch.model.FormsApiUser;
 import com.ch.resources.BarcodeResource;
+import com.ch.resources.ConfirmPaymentResource;
 import com.ch.resources.FormResponseResource;
 import com.ch.resources.FormSubmissionResource;
 import com.ch.resources.HealthcheckResource;
@@ -35,6 +36,7 @@ import com.ch.resources.TestResource;
 import com.ch.service.LoggingService;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Slf4jReporter;
+
 import de.thomaskrille.dropwizard_template_config.TemplateConfigBundle;
 import io.dropwizard.Application;
 import io.dropwizard.auth.AuthDynamicFeature;
@@ -45,6 +47,7 @@ import io.dropwizard.client.proxy.ProxyConfiguration;
 import io.dropwizard.forms.MultiPartBundle;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
+
 import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.slf4j.LoggerFactory;
 
@@ -145,6 +148,7 @@ public class FormsServiceApplication extends Application<FormsServiceConfigurati
     environment.jersey().register(new BarcodeResource(clientHelper, configuration.getCompaniesHouseConfiguration()));
     environment.jersey().register(new QueueResource(clientHelper, configuration.getCompaniesHouseConfiguration()));
     environment.jersey().register(new PresenterAuthResource(presenterHelper));
+    environment.jersey().register(new ConfirmPaymentResource());
 
     if (configuration.isTestMode()) {
       environment.jersey().register(new TestResource());

--- a/src/main/java/com/ch/application/FormsServiceApplication.java
+++ b/src/main/java/com/ch/application/FormsServiceApplication.java
@@ -141,7 +141,7 @@ public class FormsServiceApplication extends Application<FormsServiceConfigurati
 
     // Resources
     environment.jersey().register(new FormResponseResource(salesforceClientHelper, salesForceConfiguration));
-    environment.jersey().register(new FormSubmissionResource(presenterHelper));
+    environment.jersey().register(new FormSubmissionResource());
     environment.jersey().register(new FormResponseResource(salesforceClientHelper, salesForceConfiguration));
     environment.jersey().register(new HomeResource());
     environment.jersey().register(new HealthcheckResource());

--- a/src/main/java/com/ch/conversion/builders/FormJsonBuilder.java
+++ b/src/main/java/com/ch/conversion/builders/FormJsonBuilder.java
@@ -30,7 +30,7 @@ public class FormJsonBuilder {
    * @param packageJson package data json
    * @param formJson    form data json
    */
-  public FormJsonBuilder(ITransformConfig config, String packageJson, String formJson, String presenterAccountNumber) {
+  public FormJsonBuilder(ITransformConfig config, String packageJson, String formJson) {
     this.config = config;
     this.helper = JsonHelper.getInstance();
     this.pack = new JSONObject(packageJson);
@@ -45,11 +45,6 @@ public class FormJsonBuilder {
     if (attachments.length() == 0) {
       throw new MissingRequiredDataException(config.getAttachmentsPropertyNameIn() + " length is 0", "(form body part)");
     }
-
-    if (presenterAccountNumber != null) {
-      addAccountNumber(presenterAccountNumber);
-    }
-    
   }
 
   /**
@@ -112,30 +107,6 @@ public class FormJsonBuilder {
     return FormServiceConstants.PACKAGE_STATUS_DEFAULT;
   }
 
-  /**
-   * Adds account number to json object if payment number is account.
-   *
-   * @param accountNumber account number as string.
-   * @return Form as string.
-   */
-  protected JSONObject addAccountNumber(String accountNumber) {
-
-    try {
-
-      JSONObject paymentProperty = form.getJSONObject(config.getFilingDetailsPropertyNameIn())
-        .getJSONObject(config.getPaymentPropertyNameIn());
-
-      if ("account".equals(paymentProperty.get(config.getPaymentMethodPropertyNameIn()))) {
-        paymentProperty.put(config.getAccountNumberPropertyNameIn(), accountNumber);
-
-        return form;
-      }
-    } catch (JSONException ex) {
-      return form;
-    }
-    return form;
-  }
-  
   /**
    * Adds submission reference to json object
    *

--- a/src/main/java/com/ch/conversion/builders/FormXmlBuilder.java
+++ b/src/main/java/com/ch/conversion/builders/FormXmlBuilder.java
@@ -1,7 +1,7 @@
 package com.ch.conversion.builders;
 
-
 import com.ch.conversion.config.ITransformConfig;
+
 import com.ch.conversion.transformations.FilingDetailsTransform;
 import com.ch.conversion.transformations.ManualElementsTransform;
 import com.ch.conversion.transformations.MetaDataTransform;

--- a/src/main/java/com/ch/conversion/builders/JsonBuilder.java
+++ b/src/main/java/com/ch/conversion/builders/JsonBuilder.java
@@ -55,18 +55,18 @@ public class JsonBuilder {
    * @return forms package
    */
   public FormsPackage getTransformedPackage() {
-    // 1. create list of transformed forms
+    // Create list of transformed forms
     List<JSONObject> forms = new ArrayList<>();
 
-    // 2. Get the submission reference for addition to all parts of the entity
+    // Get the submission reference for addition to all parts of the entity
     String packageIdentifier = formsPackage.getPackageMetaDataJson().getString(config.getPackageIdentifierElementNameOut());
 
-    // 3. transform package meta data
+    // Transform package meta data
     JSONObject packageMetaData = getTransformedPackageMetaData();
  
     //TODO: This old presenter auth check needs to move to the payment confirm endpoint
     /**
-    // n. if there are credentials make call to presenter auth api
+    // If there are credentials make call to presenter auth api
     if (presenterAuthRequest != null) {
 
       //a. Get the presenters account number
@@ -85,29 +85,29 @@ public class JsonBuilder {
     }
     **/
     
-    // 4. loop forms and transform
+    // Loop forms and transform
     for (String formJson : formsPackage.getForms()) {
       forms.add(getBuilderJson(formJson, packageIdentifier));
     }
 
-    // 5. check the number of forms matches those prescribed in the package, if not throw an exception
+    // Check the number of forms matches those prescribed in the package, if not throw an exception
     int packageFormCount = (Integer) formsPackage.getPackageMetaDataJson().get(config.getPackageCountPropertyNameIn());
 
     if (forms.size() != packageFormCount) {
       throw new PackageContentsException(config.getPackageCountPropertyNameIn());
     }
 
-    // 6. return transformed package
+    // Return transformed package
     return new FormsPackage(packageMetaData.toString(), getFormsAsString(forms));
   }
 
   private JSONObject getTransformedPackageMetaData() {
     JSONObject packageMetaData = new JSONObject(formsPackage.getPackageMetaData());
 
-    // 1. add datetime to package meta data
+    // Add datetime to package meta data
     packageMetaData.put(config.getPackageDatePropertyNameOut(), getDateTime());
 
-    // 2. add default status
+    // Add default status
     Object status = getDefaultStatus();
     packageMetaData.put(config.getFormStatusPropertyNameOut(), status);
 

--- a/src/main/java/com/ch/conversion/builders/JsonBuilder.java
+++ b/src/main/java/com/ch/conversion/builders/JsonBuilder.java
@@ -5,12 +5,8 @@ import com.ch.client.PresenterHelper;
 import com.ch.conversion.config.ITransformConfig;
 import com.ch.conversion.helpers.MultiPartHelper;
 import com.ch.exception.PackageContentsException;
-import com.ch.exception.PresenterAuthenticationException;
 import com.ch.model.FormsPackage;
-import com.ch.model.PresenterAuthRequest;
-import com.ch.model.PresenterAuthResponse;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
-import org.json.JSONException;
 import org.json.JSONObject;
 
 import java.text.DateFormat;
@@ -28,7 +24,6 @@ public class JsonBuilder {
 
   private final ITransformConfig config;
   private final FormsPackage formsPackage;
-  private final PresenterHelper presenterHelper;
 
   /**
    * Convert FormDataMultiPart.
@@ -36,9 +31,8 @@ public class JsonBuilder {
    * @param config json and xml
    * @param parts  the form parts
    */
-  public JsonBuilder(ITransformConfig config, FormDataMultiPart parts, PresenterHelper presenterHelper) {
+  public JsonBuilder(ITransformConfig config, FormDataMultiPart parts) {
     this.config = config;
-    this.presenterHelper = presenterHelper;
     MultiPartHelper helper = MultiPartHelper.getInstance();
     this.formsPackage = helper.getPackageFromMultiPart(config, parts);
   }
@@ -50,10 +44,9 @@ public class JsonBuilder {
    * @param packageJson package data
    * @param formsJson   list of forms json (untransformed)
    */
-  public JsonBuilder(ITransformConfig config, String packageJson, List<String> formsJson, PresenterHelper presenterHelper) {
+  public JsonBuilder(ITransformConfig config, String packageJson, List<String> formsJson) {
     this.config = config;
     this.formsPackage = new FormsPackage(packageJson, formsJson);
-    this.presenterHelper = presenterHelper;
   }
 
   /**
@@ -70,12 +63,10 @@ public class JsonBuilder {
 
     // 3. transform package meta data
     JSONObject packageMetaData = getTransformedPackageMetaData();
-
-    // 4. check the package meta data for auth credentials
-    PresenterAuthRequest presenterAuthRequest = getAuthRequest(packageMetaData);
-
-    String presenterAccountNumber = null;    
-    // 5. if there are credentials make call to presenter auth api
+ 
+    //TODO: This old presenter auth check needs to move to the payment confirm endpoint
+    /**
+    // n. if there are credentials make call to presenter auth api
     if (presenterAuthRequest != null) {
 
       //a. Get the presenters account number
@@ -92,20 +83,21 @@ public class JsonBuilder {
       //c. Remove the presenterAuth from the package meta data
       packageMetaData.remove(config.getPresenterAuthPropertyNameIn());
     }
+    **/
     
-    // 6. loop forms and transform
+    // 4. loop forms and transform
     for (String formJson : formsPackage.getForms()) {
-      forms.add(getBuilderJson(formJson, presenterAccountNumber, packageIdentifier));
+      forms.add(getBuilderJson(formJson, packageIdentifier));
     }
 
-    // 7. check the number of forms matches those prescribed in the package, if not throw an exception
+    // 5. check the number of forms matches those prescribed in the package, if not throw an exception
     int packageFormCount = (Integer) formsPackage.getPackageMetaDataJson().get(config.getPackageCountPropertyNameIn());
 
     if (forms.size() != packageFormCount) {
       throw new PackageContentsException(config.getPackageCountPropertyNameIn());
     }
 
-    // 8. return transformed package
+    // 6. return transformed package
     return new FormsPackage(packageMetaData.toString(), getFormsAsString(forms));
   }
 
@@ -122,21 +114,8 @@ public class JsonBuilder {
     return packageMetaData;
   }
 
-  protected PresenterAuthRequest getAuthRequest(JSONObject packageMetaData) {
-    String presenterId, presenterAuth;
-
-    try {
-      presenterId = packageMetaData.getString(config.getPresenterIdPropertyNameIn());
-      presenterAuth = packageMetaData.getString(config.getPresenterAuthPropertyNameIn());
-    } catch (JSONException e) {
-      return null;
-    }
-    
-    return new PresenterAuthRequest(presenterId, presenterAuth);
-  }
-
-  protected JSONObject getBuilderJson(String json, String presenterAccountNumber, String packageIdentifier) {
-    FormJsonBuilder builder = new FormJsonBuilder(config, formsPackage.getPackageMetaData(), json, presenterAccountNumber);
+  protected JSONObject getBuilderJson(String json, String packageIdentifier) {
+    FormJsonBuilder builder = new FormJsonBuilder(config, formsPackage.getPackageMetaData(), json);
     return builder.getJson();
   }
 

--- a/src/main/java/com/ch/exception/NoPackageFoundException.java
+++ b/src/main/java/com/ch/exception/NoPackageFoundException.java
@@ -1,0 +1,26 @@
+package com.ch.exception;
+
+import javax.ws.rs.WebApplicationException;
+
+public class NoPackageFoundException extends WebApplicationException {
+
+  private final String packageIdentifier;
+  private final String status;
+
+  /**
+   * Exception thrown when required package is not present.
+   *
+   * @param packageIdentifier identifier for package
+   * @param status the status that was searched for
+   */
+  public NoPackageFoundException(String packageIdentifier, String status) {
+    this.packageIdentifier = packageIdentifier;
+    this.status = status;
+  }
+
+  @Override
+  public String getMessage() {
+    return String.format("Package with identifier %s and status %s was not found",
+      packageIdentifier, status);
+  }
+}

--- a/src/main/java/com/ch/exception/mapper/NoPackageFoundExceptionMapper.java
+++ b/src/main/java/com/ch/exception/mapper/NoPackageFoundExceptionMapper.java
@@ -1,0 +1,31 @@
+package com.ch.exception.mapper;
+
+import static com.ch.service.LoggingService.LoggingLevel.ERROR;
+import static com.ch.service.LoggingService.tag;
+
+import com.ch.exception.NoPackageFoundException;
+import com.ch.service.LoggingService;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.ext.ExceptionMapper;
+
+/**
+ * This is an implementation of ExceptionMapper which is mapped to an NoPackageFoundException.
+ * It will handle the exception and return an appropriate response.
+ */
+public class NoPackageFoundExceptionMapper implements ExceptionMapper<NoPackageFoundException> {
+
+  /**
+   * Returns an HTTP response containing the appropriate error message.
+   *
+   * @param exception - the MissingRequiredDataException that was thrown
+   * @return an appropriate HTTP error response
+   */
+  public Response toResponse(NoPackageFoundException exception) {
+    LoggingService.log(tag, ERROR, exception.getMessage(), NoPackageFoundException.class);
+    String error = ExceptionHelper.getInstance().getJsonError(exception);
+    return Response.status(Response.Status.NOT_FOUND)
+      .entity(error)
+      .build();
+  }
+}

--- a/src/main/java/com/ch/helpers/MongoHelper.java
+++ b/src/main/java/com/ch/helpers/MongoHelper.java
@@ -206,6 +206,18 @@ public final class MongoHelper {
     }
     return false;
   }
+  
+  /**
+   * Find packages by identifier and status
+   *
+   * @return MongoCollection
+   */
+  public FindIterable<Document> getPackagesCollectionByPackageIdAndStatus(String packageId, String status) {
+    MongoDatabase database = getDatabase();
+    return database.getCollection(configuration.getMongoDbPackagesCollectionName())
+      .find(new Document(config.getFormStatusPropertyNameOut(), status.toUpperCase(Locale.ENGLISH))
+        .append(config.getPackageIdentifierElementNameOut(), packageId));
+  }
 
   /**
    * Get the forms collection.

--- a/src/main/java/com/ch/helpers/MongoHelper.java
+++ b/src/main/java/com/ch/helpers/MongoHelper.java
@@ -208,7 +208,7 @@ public final class MongoHelper {
   }
   
   /**
-   * Find packages by identifier and status
+   * Find packages by identifier and status.
    *
    * @return MongoCollection
    */

--- a/src/main/java/com/ch/model/ConfirmPaymentRequest.java
+++ b/src/main/java/com/ch/model/ConfirmPaymentRequest.java
@@ -1,0 +1,30 @@
+package com.ch.model;
+
+public class ConfirmPaymentRequest {
+
+  private String packageIdentifier;
+  private Payment payment;
+
+  /**
+   * Constructs an empty confirm payment request.
+   */
+  public ConfirmPaymentRequest() {
+    //Empty constructor is needed for automatic deserialisation
+  }
+
+  /**
+   * Constructs an empty confirm payment request.
+   */
+  public ConfirmPaymentRequest(String packageIdentifier, Payment payment) {
+    this.packageIdentifier = packageIdentifier;
+    this.payment = payment;
+  }
+
+  public String getPackageIdentifier() {
+    return packageIdentifier;
+  }
+
+  public Payment getPayment() {
+    return payment;
+  }
+}

--- a/src/main/java/com/ch/model/FormStatus.java
+++ b/src/main/java/com/ch/model/FormStatus.java
@@ -5,6 +5,7 @@ package com.ch.model;
  */
 public enum FormStatus {
   PENDING,
+  PAID,
   SUCCESS,
   FAILED
 }

--- a/src/main/java/com/ch/model/Payment.java
+++ b/src/main/java/com/ch/model/Payment.java
@@ -1,0 +1,36 @@
+package com.ch.model;
+
+public class Payment {
+
+  private String referenceNumber;
+  private String paymentMethod;
+  private String accountNumber;
+
+  /**
+   * Constructs an empty confirm payment request.
+   */
+  public Payment() {
+    //Empty constructor is needed for automatic deserialisation
+  }
+
+  /**
+   * Constructs an empty confirm payment request.
+   */
+  public Payment(String referenceNumber, String paymentMethod, String accountNumber) {
+    this.referenceNumber = referenceNumber;
+    this.paymentMethod = paymentMethod;
+    this.accountNumber = accountNumber;
+  }
+
+  public String getReferenceNumber() {
+    return referenceNumber;
+  }
+  
+  public String getPaymentMethod() {
+    return paymentMethod;
+  }
+
+  public String getAccountNumber() {
+    return accountNumber;
+  }
+}

--- a/src/main/java/com/ch/model/Payment.java
+++ b/src/main/java/com/ch/model/Payment.java
@@ -5,6 +5,7 @@ public class Payment {
   private String referenceNumber;
   private String paymentMethod;
   private String accountNumber;
+  private String accountAuthCode;
 
   /**
    * Constructs an empty confirm payment request.
@@ -16,10 +17,11 @@ public class Payment {
   /**
    * Constructs an empty confirm payment request.
    */
-  public Payment(String referenceNumber, String paymentMethod, String accountNumber) {
+  public Payment(String referenceNumber, String paymentMethod, String accountNumber, String accountAuthCode) {
     this.referenceNumber = referenceNumber;
     this.paymentMethod = paymentMethod;
     this.accountNumber = accountNumber;
+    this.accountAuthCode = accountAuthCode;
   }
 
   public String getReferenceNumber() {
@@ -32,5 +34,9 @@ public class Payment {
 
   public String getAccountNumber() {
     return accountNumber;
+  }
+  
+  public String getAccountAuthCode() {
+    return accountAuthCode;
   }
 }

--- a/src/main/java/com/ch/resources/ConfirmPaymentResource.java
+++ b/src/main/java/com/ch/resources/ConfirmPaymentResource.java
@@ -46,11 +46,6 @@ public class ConfirmPaymentResource {
     try {
       LoggingService.log(tag, INFO, "ConfirmPaymentRequest from Salesforce: " + confirmPaymentRequest,
         ConfirmPaymentResource.class);
-
-      // POST to Barcode Service
-      //Response response = client.postJson(configuration.getBarcodeServiceUrl(), dateReceived);
-      //LoggingService.log(tag, INFO, "Response from Barcode Service " + response,
-        //ConfirmPaymentResource.class);
       
       // Try to find an existing package with the supplied identifier and status of PENDING
       ArrayList<Document> packages = MongoHelper.getInstance().getPackagesCollectionByPackageIdAndStatus(

--- a/src/main/java/com/ch/resources/ConfirmPaymentResource.java
+++ b/src/main/java/com/ch/resources/ConfirmPaymentResource.java
@@ -1,0 +1,72 @@
+package com.ch.resources;
+
+import static com.ch.service.LoggingService.LoggingLevel.INFO;
+import static com.ch.service.LoggingService.tag;
+
+import com.ch.application.FormsServiceApplication;
+import com.ch.exception.NoPackageFoundException;
+import com.ch.helpers.MongoHelper;
+import com.ch.model.ConfirmPaymentRequest;
+import com.ch.model.FormStatus;
+import com.ch.service.LoggingService;
+import com.codahale.metrics.Timer;
+
+import io.dropwizard.auth.Auth;
+
+import org.bson.Document;
+
+import java.util.ArrayList;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+/**
+ * Confirm Payment Resource to update status and payment details for previous submission.
+ */
+@Path("/confirmpaid")
+public class ConfirmPaymentResource {
+  private static final Timer timer = FormsServiceApplication.registry.timer("ConfirmPaymentResource");
+
+
+  /**
+   * Checks for existing packageReference with a status of PENDING and updates the payment information
+   * and the status to PAID.
+   *
+   * @return response - 200 or 400
+   */
+  @POST
+  @Consumes(MediaType.APPLICATION_JSON)
+  @Produces(MediaType.APPLICATION_JSON)
+  public Response confirmPaid(@Auth ConfirmPaymentRequest confirmPaymentRequest) {
+    final Timer.Context context = timer.time();
+    try {
+      LoggingService.log(tag, INFO, "ConfirmPaymentRequest from Salesforce: " + confirmPaymentRequest,
+        ConfirmPaymentResource.class);
+
+      // POST to Barcode Service
+      //Response response = client.postJson(configuration.getBarcodeServiceUrl(), dateReceived);
+      //LoggingService.log(tag, INFO, "Response from Barcode Service " + response,
+        //ConfirmPaymentResource.class);
+      
+      // Try to find an existing package with the supplied identifier and status of PENDING
+      ArrayList<Document> packages = MongoHelper.getInstance().getPackagesCollectionByPackageIdAndStatus(
+        confirmPaymentRequest.getPackageIdentifier(), FormStatus.PENDING.toString()).into(new ArrayList<Document>());
+      if ( packages.size() == 1 ) {
+        return Response.ok("Payment confirmed for package " + confirmPaymentRequest.getPackageIdentifier()).build();
+      } else {
+        LoggingService.log(tag, INFO, "ConfirmPaymentRequest from Salesforce - no packages found: " + confirmPaymentRequest,
+          ConfirmPaymentResource.class);
+        throw new NoPackageFoundException(confirmPaymentRequest.getPackageIdentifier(), FormStatus.PENDING.toString());
+      }
+      
+      
+
+    } finally {
+      context.stop();
+    }
+  }
+}

--- a/src/main/java/com/ch/resources/FormSubmissionResource.java
+++ b/src/main/java/com/ch/resources/FormSubmissionResource.java
@@ -1,7 +1,6 @@
 package com.ch.resources;
 
 import com.ch.application.FormsServiceApplication;
-import com.ch.client.PresenterHelper;
 import com.ch.conversion.builders.JsonBuilder;
 import com.ch.conversion.config.ITransformConfig;
 import com.ch.conversion.config.TransformConfig;
@@ -26,17 +25,6 @@ public class FormSubmissionResource {
 
   private static final Timer timer = FormsServiceApplication.registry.timer("FormSubmissionResource");
 
-  private final PresenterHelper presenterHelper;
-
-  /**
-   * Constructor for form submission resource.
-   *
-   * @param presenterHelper helper for getting presenter account numbers.
-   */
-  public FormSubmissionResource(PresenterHelper presenterHelper) {
-    this.presenterHelper = presenterHelper;
-  }
-
   /**
    * Resource to post forms from Salesforce to CHIPS.
    *
@@ -51,7 +39,7 @@ public class FormSubmissionResource {
     try {
       // convert input to json
       ITransformConfig config = new TransformConfig();
-      JsonBuilder builder = new JsonBuilder(config, multi, presenterHelper);
+      JsonBuilder builder = new JsonBuilder(config, multi);
       FormsPackage transformedPackage = builder.getTransformedPackage();
 
       // insert into mongodb

--- a/src/test/java/com/ch/conversion/builders/FormJsonBuilderTest.java
+++ b/src/test/java/com/ch/conversion/builders/FormJsonBuilderTest.java
@@ -36,14 +36,14 @@ public class FormJsonBuilderTest extends TestHelper {
     @Test(expected = JSONException.class)
     public void throwsJSONExceptionWithInvalidJson() throws Exception {
         String invalid = getStringFromFile(INVALID_JSON_PATH);
-        FormJsonBuilder builder = new FormJsonBuilder(config, invalid, invalid,TEST_PRESENTER_ACCOUNT);
+        FormJsonBuilder builder = new FormJsonBuilder(config, invalid, invalid);
         builder.getJson();
     }
 
     @Test(expected = MissingRequiredDataException.class)
     public void throwsMissingRequiredDataExceptionWithValidJsonMissingRequiredData() throws Exception {
         String valid = getStringFromFile(VALID_JSON_PATH);
-        FormJsonBuilder builder = new FormJsonBuilder(config, valid, valid, TEST_PRESENTER_ACCOUNT);
+        FormJsonBuilder builder = new FormJsonBuilder(config, valid, valid);
         builder.getJson();
     }
     
@@ -51,7 +51,7 @@ public class FormJsonBuilderTest extends TestHelper {
     public void throwsMissingRequiredDataExceptionWithValidJsonMissingAttachemnts() throws Exception {
         String validPackage = getStringFromFile(PACKAGE_JSON_PATH);
         String validForm = getStringFromFile(FORM_ALL_JSON_MISSING_ATTACHMENT);
-        FormJsonBuilder builder = new FormJsonBuilder(config, validPackage, validForm, TEST_PRESENTER_ACCOUNT);
+        FormJsonBuilder builder = new FormJsonBuilder(config, validPackage, validForm);
         builder.getJson();
     }
 
@@ -62,21 +62,12 @@ public class FormJsonBuilderTest extends TestHelper {
         Assert.assertNotNull(json);
     }
 
-    @Test
-    public void shouldAddAccountNumber() throws Exception {
-        FormJsonBuilder builder = getValidFormJsonBuilder();
-        JSONObject formJson = builder.getForm();
-        Assert.assertTrue(TEST_PRESENTER_ACCOUNT.equals(formJson.getJSONObject(config.getFilingDetailsPropertyNameIn())
-          .getJSONObject("payment")
-          .get("accountNumber")));
-    }
-
     private FormJsonBuilder getValidFormJsonBuilder() throws Exception {
         // valid package data
         String package_string = getStringFromFile(PACKAGE_JSON_PATH);
         // valid form data
         String form_string = getStringFromFile(FORM_ALL_JSON_NO_ACC_NUMBER_PATH);
         // builder
-        return new FormJsonBuilder(config, package_string, form_string, TEST_PRESENTER_ACCOUNT);
+        return new FormJsonBuilder(config, package_string, form_string);
     }
 }

--- a/src/test/java/com/ch/conversion/builders/JsonBuilderTest.java
+++ b/src/test/java/com/ch/conversion/builders/JsonBuilderTest.java
@@ -1,13 +1,11 @@
 package com.ch.conversion.builders;
 
-import com.ch.application.FormServiceConstants;
 import com.ch.client.PresenterHelper;
 import com.ch.conversion.config.ITransformConfig;
 import com.ch.conversion.config.TransformConfig;
 import com.ch.exception.MissingRequiredDataException;
 import com.ch.helpers.TestHelper;
 import com.ch.model.FormsPackage;
-import com.ch.model.PresenterAuthRequest;
 import com.ch.model.PresenterAuthResponse;
 
 import org.apache.commons.codec.binary.Base64;
@@ -19,12 +17,10 @@ import org.junit.Before;
 import org.junit.Test;
 
 import java.io.IOException;
-import java.text.DateFormat;
-import java.text.SimpleDateFormat;
+
 import java.util.ArrayList;
-import java.util.Date;
 import java.util.List;
-import java.util.Locale;
+
 
 import javax.ws.rs.core.MediaType;
 
@@ -57,7 +53,7 @@ public class JsonBuilderTest extends TestHelper {
         for (int i = 0; i < 2; i++) {
             invalid_forms.add(invalid);
         }
-        JsonBuilder builder = new JsonBuilder(config, invalid, invalid_forms, helper);
+        JsonBuilder builder = new JsonBuilder(config, invalid, invalid_forms);
         builder.getTransformedPackage();
     }
 
@@ -68,7 +64,7 @@ public class JsonBuilderTest extends TestHelper {
         for (int i = 0; i < 2; i++) {
             valid_json_forms.add(valid);
         }
-        JsonBuilder builder = new JsonBuilder(config, valid, valid_json_forms, helper);
+        JsonBuilder builder = new JsonBuilder(config, valid, valid_json_forms);
         builder.getTransformedPackage();
     }
 
@@ -82,43 +78,16 @@ public class JsonBuilderTest extends TestHelper {
     @Test(expected = Exception.class)
     public void throwsExceptionWithEmptyMultiPart() throws Exception {
         FormDataMultiPart multi = new FormDataMultiPart();
-        JsonBuilder builder = new JsonBuilder(config, multi,helper);
+        JsonBuilder builder = new JsonBuilder(config, multi);
         builder.getTransformedPackage();
     }
 
     @Test
     public void createStringForValidMultiPart() throws Exception {
         FormDataMultiPart multi = getValidMultiPart();
-        JsonBuilder builder = new JsonBuilder(config, multi, helper);
+        JsonBuilder builder = new JsonBuilder(config, multi);
         FormsPackage transformedPackage = builder.getTransformedPackage();
         Assert.assertNotNull(transformedPackage);
-    }
-
-    @Test
-    public void shouldReturnNullObject() throws IOException {
-        FormDataMultiPart multi = getValidMultiPart();
-        JsonBuilder builder = new JsonBuilder(config, multi, helper);
-        JSONObject object = new JSONObject();
-        Assert.assertFalse(builder.getAuthRequest(object) instanceof PresenterAuthRequest);
-    }
-
-    @Test
-    public void shouldReturnPresenterAuthRequest() throws IOException {
-        FormDataMultiPart multi = getValidMultiPart();
-        JsonBuilder builder = new JsonBuilder(config, multi, helper);
-        JSONObject object = new JSONObject();
-        object.put("presenterId", "1234567");
-        object.put("presenterAuth", "1234567");
-        Assert.assertTrue(builder.getAuthRequest(object) instanceof PresenterAuthRequest);
-    }
-
-    @Test(expected = JSONException.class)
-    public void shouldRemovePresenterAuth() throws IOException {
-        FormDataMultiPart multi = getValidMultiPart();
-        JsonBuilder builder = new JsonBuilder(config, multi, helper);
-        FormsPackage transformedPackage = builder.getTransformedPackage();
-        JSONObject packageMetadata = transformedPackage.getPackageMetaDataJson();
-        packageMetadata.getString(config.getPresenterAuthPropertyNameIn());
     }
 
     private JsonBuilder getValidJsonBuilder() throws Exception {
@@ -131,7 +100,7 @@ public class JsonBuilderTest extends TestHelper {
             valid_forms.add(valid);
         }
         // builder
-        return new JsonBuilder(config, package_string, valid_forms, helper);
+        return new JsonBuilder(config, package_string, valid_forms);
     }
 
     @Test
@@ -146,7 +115,7 @@ public class JsonBuilderTest extends TestHelper {
         valid_forms.add(valid.replaceAll("J53W9DA1", "J53W9DA2"));
 
         // when this package is transformed
-        FormsPackage pack =  new JsonBuilder(config, package_string, valid_forms, helper).getTransformedPackage();
+        FormsPackage pack =  new JsonBuilder(config, package_string, valid_forms).getTransformedPackage();
 
         //all elements should contain a unique submissionReference
         String formOneBarcode = pack.getFormsJSon().get(0).getString(config.getBarcodePropertyNameOut());

--- a/src/test/java/com/ch/cucumber/ActivationSteps.java
+++ b/src/test/java/com/ch/cucumber/ActivationSteps.java
@@ -79,7 +79,7 @@ public class ActivationSteps extends TestHelper {
     for (int i = 0; i < 2; i++) {
       valid_forms.add(valid);
     }
-    FormsPackage formsPackage = new JsonBuilder(config, packageOneString, valid_forms,presenterHelper).getTransformedPackage();
+    FormsPackage formsPackage = new JsonBuilder(config, packageOneString, valid_forms).getTransformedPackage();
     // insert package one into db
     helper.storeFormsPackage(formsPackage);
 
@@ -91,7 +91,7 @@ public class ActivationSteps extends TestHelper {
     for (int i = 0; i < 1; i++) {
       valid_forms2.add(valid2);
     }
-    FormsPackage formsPackage2 = new JsonBuilder(config, packageTwoString, valid_forms2, presenterHelper).getTransformedPackage();
+    FormsPackage formsPackage2 = new JsonBuilder(config, packageTwoString, valid_forms2).getTransformedPackage();
     // insert package two into db
     TimeUnit.SECONDS.sleep(1);
     helper.storeFormsPackage(formsPackage2);
@@ -104,7 +104,7 @@ public class ActivationSteps extends TestHelper {
     for (int i = 0; i < 5; i++) {
       valid_forms3.add(valid3);
     }
-    FormsPackage formsPackage3 = new JsonBuilder(config, packageThreeString, valid_forms3, presenterHelper).getTransformedPackage();
+    FormsPackage formsPackage3 = new JsonBuilder(config, packageThreeString, valid_forms3).getTransformedPackage();
     // insert package three into db
     TimeUnit.SECONDS.sleep(1);
     helper.storeFormsPackage(formsPackage3);
@@ -155,7 +155,7 @@ public class ActivationSteps extends TestHelper {
     for (int i = 0; i < 2; i++) {
       valid_forms4.add(valid4);
     }
-    FormsPackage formsPackage = new JsonBuilder(config, packageFourString, valid_forms4, presenterHelper).getTransformedPackage();
+    FormsPackage formsPackage = new JsonBuilder(config, packageFourString, valid_forms4).getTransformedPackage();
     // insert package one into db
     helper.storeFormsPackage(formsPackage);
 

--- a/src/test/java/com/ch/cucumber/PresenterAuthSteps.java
+++ b/src/test/java/com/ch/cucumber/PresenterAuthSteps.java
@@ -1,6 +1,5 @@
 package com.ch.cucumber;
 
-import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -23,14 +22,12 @@ import io.dropwizard.client.JerseyClientBuilder;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.glassfish.jersey.internal.util.Base64;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
-import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.json.JSONObject;
 import org.junit.Assert;
 
 import java.util.concurrent.TimeUnit;
 
 import javax.ws.rs.client.Client;
-import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -125,7 +122,7 @@ public class PresenterAuthSteps extends TestHelper{
     multi.field("form2", form2, MediaType.APPLICATION_JSON_TYPE);
 
 
-    FormSubmissionResource resource = new FormSubmissionResource(presenterHelper);
+    FormSubmissionResource resource = new FormSubmissionResource();
     resource.postForms(multi);
   }
 
@@ -164,7 +161,7 @@ public class PresenterAuthSteps extends TestHelper{
 
   @Then("^An exception should be thrown and no submision should take place$")
   public void an_exception_should_be_thrown_and_no_submision_should_take_place() throws Throwable {
-    FormSubmissionResource resource = new FormSubmissionResource(presenterHelper);
+    FormSubmissionResource resource = new FormSubmissionResource();
 
     try{
       resource.postForms(multi);
@@ -195,7 +192,7 @@ public class PresenterAuthSteps extends TestHelper{
     String form3 = getStringFromFile(FORM_ALL_JSON_NO_ACC_NUMBER_PATH);
     multi.field("form3", form3, MediaType.APPLICATION_JSON_TYPE);
 
-    FormSubmissionResource resource = new FormSubmissionResource(presenterHelper);
+    FormSubmissionResource resource = new FormSubmissionResource();
     resource.postForms(multi);
   }
 

--- a/src/test/java/com/ch/helpers/MongoHelperTest.java
+++ b/src/test/java/com/ch/helpers/MongoHelperTest.java
@@ -11,17 +11,12 @@ import com.ch.configuration.FormsServiceConfiguration;
 import com.ch.conversion.builders.JsonBuilder;
 import com.ch.conversion.config.ITransformConfig;
 import com.ch.conversion.config.TransformConfig;
-import com.ch.cucumber.FormServiceTestSuiteIT;
 import com.ch.model.FormStatus;
 import com.ch.model.FormsPackage;
 import com.ch.model.PresenterAuthResponse;
-import com.google.common.collect.Lists;
-import com.mongodb.client.FindIterable;
-import com.mongodb.client.MongoCollection;
 import io.dropwizard.testing.ResourceHelpers;
 import io.dropwizard.testing.junit.DropwizardAppRule;
 import org.bson.Document;
-import org.json.JSONObject;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -31,7 +26,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Created by Aaron.Witter on 18/07/2016.
@@ -73,7 +67,7 @@ public class MongoHelperTest extends TestHelper{
             valid_forms.add(valid);
         }
         // builder
-        FormsPackage formsPackage = new JsonBuilder(config, package_string, valid_forms, presenterHelper).getTransformedPackage();
+        FormsPackage formsPackage = new JsonBuilder(config, package_string, valid_forms).getTransformedPackage();
 
         helper.storeFormsPackage(formsPackage);
 
@@ -86,7 +80,7 @@ public class MongoHelperTest extends TestHelper{
             valid_forms2.add(valid2);
         }
         // builder
-        FormsPackage formsPackage2 = new JsonBuilder(config, package_string2, valid_forms2, presenterHelper).getTransformedPackage();
+        FormsPackage formsPackage2 = new JsonBuilder(config, package_string2, valid_forms2).getTransformedPackage();
 
         helper.storeFormsPackage(formsPackage2);
 
@@ -112,7 +106,7 @@ public class MongoHelperTest extends TestHelper{
             valid_forms.add(valid);
         }
         // builder
-        FormsPackage formsPackage = new JsonBuilder(config, package_string, valid_forms, presenterHelper).getTransformedPackage();
+        FormsPackage formsPackage = new JsonBuilder(config, package_string, valid_forms).getTransformedPackage();
 
         helper.storeFormsPackage(formsPackage);
 
@@ -125,7 +119,7 @@ public class MongoHelperTest extends TestHelper{
             valid_forms2.add(valid2);
         }
         // builder
-        FormsPackage formsPackage2 = new JsonBuilder(config, package_string2, valid_forms2, presenterHelper).getTransformedPackage();
+        FormsPackage formsPackage2 = new JsonBuilder(config, package_string2, valid_forms2).getTransformedPackage();
 
         helper.storeFormsPackage(formsPackage2);
 
@@ -147,7 +141,7 @@ public class MongoHelperTest extends TestHelper{
             valid_forms.add(valid);
         }
         // builder
-        FormsPackage formsPackage = new JsonBuilder(config, package_string, valid_forms, presenterHelper).getTransformedPackage();
+        FormsPackage formsPackage = new JsonBuilder(config, package_string, valid_forms).getTransformedPackage();
 
         helper.storeFormsPackage(formsPackage);
 
@@ -160,7 +154,7 @@ public class MongoHelperTest extends TestHelper{
             valid_forms2.add(valid2);
         }
         // builder
-        FormsPackage formsPackage2 = new JsonBuilder(config, package_string2, valid_forms2, presenterHelper).getTransformedPackage();
+        FormsPackage formsPackage2 = new JsonBuilder(config, package_string2, valid_forms2).getTransformedPackage();
 
         helper.storeFormsPackage(formsPackage2);
 
@@ -182,7 +176,7 @@ public class MongoHelperTest extends TestHelper{
             valid_forms.add(valid);
         }
         // builder
-        FormsPackage formsPackage = new JsonBuilder(config, package_string, valid_forms, presenterHelper).getTransformedPackage();
+        FormsPackage formsPackage = new JsonBuilder(config, package_string, valid_forms).getTransformedPackage();
 
         helper.storeFormsPackage(formsPackage);
 
@@ -206,7 +200,7 @@ public class MongoHelperTest extends TestHelper{
             valid_forms.add(valid);
         }
         // builder
-        FormsPackage formsPackage = new JsonBuilder(config, package_string, valid_forms, presenterHelper).getTransformedPackage();
+        FormsPackage formsPackage = new JsonBuilder(config, package_string, valid_forms).getTransformedPackage();
 
         helper.storeFormsPackage(formsPackage);
 

--- a/src/test/java/com/ch/helpers/QueueHelperTest.java
+++ b/src/test/java/com/ch/helpers/QueueHelperTest.java
@@ -70,7 +70,7 @@ public class QueueHelperTest extends TestHelper {
       valid_forms.add(valid);
     }
     // builder
-    FormsPackage formsPackage = new JsonBuilder(config, package_string, valid_forms, presenterHelper).getTransformedPackage();
+    FormsPackage formsPackage = new JsonBuilder(config, package_string, valid_forms).getTransformedPackage();
 
     helper.storeFormsPackage(formsPackage);
 
@@ -97,7 +97,7 @@ public class QueueHelperTest extends TestHelper {
       valid_forms.add(valid);
     }
     // builder
-    FormsPackage formsPackage = new JsonBuilder(config, package_string, valid_forms, presenterHelper).getTransformedPackage();
+    FormsPackage formsPackage = new JsonBuilder(config, package_string, valid_forms).getTransformedPackage();
 
     helper.storeFormsPackage(formsPackage);
 


### PR DESCRIPTION
This adds a new /confirmpaid endpoint (unimplemented) and removes the account number lookup/auth from the main form submission.  This is to allow integration work to commence on the Salesforce side, whilst we carry on and implement the functionality to update the payment details in the xml already in mongo etc.
