### PR TITLE
Add functionality for new /confirmpayment endpoint

### DIFF
--- a/src/main/java/com/ch/application/FormServiceConstants.java
+++ b/src/main/java/com/ch/application/FormServiceConstants.java
@@ -14,6 +14,9 @@ public class FormServiceConstants {
 
   public static final String PACKAGE_METADATA_NAME = "package";
   public static final String PACKAGE_STATUS_DEFAULT = FormStatus.PENDING.toString().toUpperCase(Locale.ENGLISH);
+  public static final String PACKAGE_STATUS_NEEDS_PAYMENT = FormStatus.UNPAID.toString().toUpperCase(Locale.ENGLISH);
+  
+  public static final String PAYMENT_TYPE_ACCOUNT = "account";
 
   public static final String DATABASE_OBJECTID_KEY = "_id";
   public static final String DATABASE_FORMS_COLLECTION_NAME = "forms";

--- a/src/main/java/com/ch/application/FormsServiceApplication.java
+++ b/src/main/java/com/ch/application/FormsServiceApplication.java
@@ -8,6 +8,7 @@ import com.ch.client.PresenterHelper;
 import com.ch.client.SalesforceClientHelper;
 import com.ch.configuration.FormsServiceConfiguration;
 import com.ch.configuration.SalesforceConfiguration;
+import com.ch.conversion.config.TransformConfig;
 import com.ch.exception.mapper.ConnectionExceptionMapper;
 import com.ch.exception.mapper.ContentTypeExceptionMapper;
 import com.ch.exception.mapper.DatabaseExceptionMapper;
@@ -22,6 +23,7 @@ import com.ch.filters.RateLimitFilter;
 import com.ch.health.AppHealthCheck;
 import com.ch.health.MongoHealthCheck;
 import com.ch.helpers.ClientHelper;
+import com.ch.helpers.ConfirmPaymentHelper;
 import com.ch.helpers.MongoHelper;
 import com.ch.model.FormsApiUser;
 import com.ch.resources.BarcodeResource;
@@ -117,6 +119,7 @@ public class FormsServiceApplication extends Application<FormsServiceConfigurati
 
     final ClientHelper clientHelper = new ClientHelper(client);
     final PresenterHelper presenterHelper = new PresenterHelper(client, configuration.getCompaniesHouseConfiguration());
+    final ConfirmPaymentHelper confirmPaymentHelper = new ConfirmPaymentHelper(new TransformConfig(), presenterHelper);
 
     SalesforceConfiguration salesForceConfiguration = configuration.getSalesforceConfiguration();
     final SalesforceClientHelper salesforceClientHelper;
@@ -148,7 +151,7 @@ public class FormsServiceApplication extends Application<FormsServiceConfigurati
     environment.jersey().register(new BarcodeResource(clientHelper, configuration.getCompaniesHouseConfiguration()));
     environment.jersey().register(new QueueResource(clientHelper, configuration.getCompaniesHouseConfiguration()));
     environment.jersey().register(new PresenterAuthResource(presenterHelper));
-    environment.jersey().register(new ConfirmPaymentResource());
+    environment.jersey().register(new ConfirmPaymentResource(confirmPaymentHelper));
 
     if (configuration.isTestMode()) {
       environment.jersey().register(new TestResource());

--- a/src/main/java/com/ch/client/PresenterHelper.java
+++ b/src/main/java/com/ch/client/PresenterHelper.java
@@ -28,7 +28,6 @@ public class PresenterHelper {
   public PresenterAuthResponse getPresenterResponse(String presenterId, String presenterAuth) {
     String authUrl = configuration.getPresenterAuthUrl() + "?id=" + presenterId + "&auth=" + presenterAuth;
     final WebTarget target = client.target(authUrl);
-//    String encode = Base64.encodeAsString(name + ":" + password);
     Response response = target.request().get();
     return response.readEntity(PresenterAuthResponse.class);
 

--- a/src/main/java/com/ch/conversion/builders/FormJsonBuilder.java
+++ b/src/main/java/com/ch/conversion/builders/FormJsonBuilder.java
@@ -53,30 +53,35 @@ public class FormJsonBuilder {
    * @return transformed json
    */
   public JSONObject getJson() {
-    // 1. create empty json object
+    // Create empty json object
     JSONObject output = new JSONObject();
 
-    // 2. add attachments
+    // Add attachments
     output.put(config.getAttachmentsPropertyNameOut(), attachments);
 
-    // 3. add barcode
+    // Add barcode
     Object barcode = getFormBarcode();
     output.put(config.getBarcodePropertyNameOut(), barcode);
     
-    // 4. add package identifier
+    // Add package identifier
     Object packageIdentifier = getPackageIdentifier();
     output.put(config.getPackageIdentifierPropertyNameIn(), packageIdentifier);
     
-    // 5. add submissionReference
+    // Add submissionReference
     String submissionReference = getSubmissionReference(packageIdentifier.toString(), barcode.toString());
     addSubmissionReference(submissionReference);
     output.put(config.getSubmissionReferenceElementNameOut(), submissionReference);
 
-    // 6. add default status
+    // Add default status
     Object status = getDefaultStatus();
+    if ( config.getPaidFormList().contains(meta.getString(config.getFormTypePropertyNameIn())) ) {
+      status = FormServiceConstants.PACKAGE_STATUS_NEEDS_PAYMENT;
+    }
+    System.out.println(meta.getString(config.getFormTypePropertyNameIn()));
+    
     output.put(config.getFormStatusPropertyNameOut(), status);
 
-    // 7. transform package and form json into base64 xml
+    // Transform package and form json into base64 xml
     String xml = getFormXML();
     output.put(config.getXmlPropertyNameOut(), xml);
     return output;

--- a/src/main/java/com/ch/conversion/builders/FormXmlBuilder.java
+++ b/src/main/java/com/ch/conversion/builders/FormXmlBuilder.java
@@ -45,25 +45,38 @@ public class FormXmlBuilder {
    * @return base64 encoded xml
    */
   public String getXML() {
-    // 1. convert form data strings to upper case in the json
+    // Convert form data strings to upper case in the json
     UpperCaseTransform.getInstance().parentUpperCase(form, config.getCaseTransformExceptions());
 
-    // 2. convert the form json straight to xml
+    //Overwrite any payment data with placeholder
+    JSONObject jsonXmlFilingDetails = form.optJSONObject(config.getFilingDetailsPropertyNameIn());
+    if ( jsonXmlFilingDetails != null ) {
+      
+      JSONObject jsonPayment = new JSONObject();
+      jsonPayment.put(config.getReferenceNumberPropertyNameIn(), config.getReferenceNumberPlaceholderValueOut());
+      jsonPayment.put(config.getPaymentMethodPropertyNameIn(), config.getPaymentMethodPlaceholderValueOut());
+      jsonPayment.put(config.getAccountNumberPropertyNameIn(), config.getAccountNumberPlaceholderValueOut());
+      
+      jsonXmlFilingDetails.put(config.getPaymentPropertyNameIn(), jsonPayment);
+      form.put(config.getFilingDetailsPropertyNameIn(), jsonXmlFilingDetails);
+    }
+    
+    // Convert the form json straight to xml
     String xml = toXml();
 
-    // 3. add root element and meta data attributes to the xml
+    // Add root element and meta data attributes to the xml
     String metaXml = addMetaData(xml);
 
-    // 4. add extra filing details
+    // Add extra filing details
     String filingDetailsXml = addFilingDetails(metaXml);
 
-    // 5. add any manual elements into the xml
+    // Add any manual elements into the xml
     String manualXml = addManualElements(filingDetailsXml);
 
-    // 6. validate xml against form xsd
+    // Validate xml against form xsd
     validateXml(manualXml);
 
-    // 7. base64 encode
+    // Base64 encode
     return encode(manualXml);
   }
 

--- a/src/main/java/com/ch/conversion/config/ITransformConfig.java
+++ b/src/main/java/com/ch/conversion/config/ITransformConfig.java
@@ -54,10 +54,17 @@ public interface ITransformConfig {
   String getPaymentMethodElementNameOut();
 
   String getAccountNumberPropertyNameIn();
+  
+  String getReferenceNumberPropertyNameIn();
 
   String getAccountNumberElementNameOut();
 
+  String getPaymentMethodPlaceholderValueOut();
 
+  String getAccountNumberPlaceholderValueOut();
+  
+  String getReferenceNumberPlaceholderValueOut();
+  
   // meta data
   String getRootElementNameOut();
 
@@ -76,4 +83,6 @@ public interface ITransformConfig {
   String getSchemasLocation();
   
   List<String> getCaseTransformExceptions();
+  
+  List<String> getPaidFormList();
 }

--- a/src/main/java/com/ch/conversion/config/TransformConfig.java
+++ b/src/main/java/com/ch/conversion/config/TransformConfig.java
@@ -104,7 +104,23 @@ public class TransformConfig implements ITransformConfig {
   public String getAccountNumberElementNameOut() {
     return "accountNumber";
   }
+  
+  public String getReferenceNumberPropertyNameIn() {
+    return "referenceNumber";
+  }
 
+  public String getReferenceNumberPlaceholderValueOut() {
+    return ":placeholderReferenceNumber:";
+  }
+  
+  public String getPaymentMethodPlaceholderValueOut() {
+    return ":placeholderPaymentMethod:";
+  }
+
+  public String getAccountNumberPlaceholderValueOut() {
+    return ":placeholderAccountNumber:";
+  }
+  
   public String getRootElementNameOut() {
     return "form";
   }
@@ -152,5 +168,17 @@ public class TransformConfig implements ITransformConfig {
     exceptions.add("/filingDetails/presenterDetails/presenterEmailOut");
 
     return exceptions;
+  }
+  
+  /**
+   * Return a list of forms that require payment.
+   *
+   * @return List
+   */
+  public List<String> getPaidFormList() {
+    List<String> paidFormTypes = new ArrayList<String>();
+    paidFormTypes.add("DS01");
+    paidFormTypes.add("LLDS01");
+    return paidFormTypes;
   }
 }

--- a/src/main/java/com/ch/conversion/transformations/FilingDetailsTransform.java
+++ b/src/main/java/com/ch/conversion/transformations/FilingDetailsTransform.java
@@ -1,6 +1,5 @@
 package com.ch.conversion.transformations;
 
-
 import com.ch.conversion.config.ITransformConfig;
 import com.ch.conversion.helpers.XmlHelper;
 import org.json.JSONObject;

--- a/src/main/java/com/ch/helpers/ConfirmPaymentHelper.java
+++ b/src/main/java/com/ch/helpers/ConfirmPaymentHelper.java
@@ -105,7 +105,7 @@ public class ConfirmPaymentHelper {
 
     unEncodedXml = unEncodedXml.replace(config.getReferenceNumberPlaceholderValueOut(), payment.getReferenceNumber());
     unEncodedXml = unEncodedXml.replace(config.getPaymentMethodPlaceholderValueOut(), payment.getPaymentMethod());
-    unEncodedXml = unEncodedXml.replace(config.getAccountNumberPlaceholderValueOut(), payment.getAccountNumber());
+    unEncodedXml = unEncodedXml.replace(config.getAccountNumberPlaceholderValueOut(), presenterAccountNumber);
     
     base64EncodedXml = new String(Base64.encodeBase64(unEncodedXml.getBytes()));
     

--- a/src/main/java/com/ch/helpers/ConfirmPaymentHelper.java
+++ b/src/main/java/com/ch/helpers/ConfirmPaymentHelper.java
@@ -1,0 +1,134 @@
+package com.ch.helpers;
+
+import static com.ch.service.LoggingService.LoggingLevel.INFO;
+import static com.ch.service.LoggingService.tag;
+
+import com.ch.application.FormServiceConstants;
+import com.ch.client.PresenterHelper;
+import com.ch.conversion.config.ITransformConfig;
+import com.ch.exception.DatabaseException;
+import com.ch.exception.NoPackageFoundException;
+import com.ch.exception.PresenterAuthenticationException;
+import com.ch.model.ConfirmPaymentRequest;
+import com.ch.model.Payment;
+import com.ch.model.PresenterAuthResponse;
+import com.ch.resources.ConfirmPaymentResource;
+import com.ch.service.LoggingService;
+import org.apache.commons.codec.binary.Base64;
+import org.bson.Document;
+import org.json.JSONObject;
+
+import java.util.ArrayList;
+
+public class ConfirmPaymentHelper {
+
+  private final ITransformConfig config;
+  private final MongoHelper helper = MongoHelper.getInstance();
+  private final PresenterHelper presenterHelper;
+  
+  public ConfirmPaymentHelper(ITransformConfig configuration, PresenterHelper presenterHelper) {
+    this.config = configuration;
+    this.presenterHelper = presenterHelper;
+  }
+  
+  /**
+   * Search for a package and update the form xml with the payment data and the form and package status to PEDNING.
+   * 
+   * @param confirmPaymentRequest the model of the payment confirmation request.
+   */
+  public void confirm(ConfirmPaymentRequest confirmPaymentRequest) {
+    
+    // Try to find an existing package with the supplied identifier and status of UNPAID
+    ArrayList<Document> packages = helper.getPackagesCollectionByPackageIdAndStatus(
+      confirmPaymentRequest.getPackageIdentifier(), FormServiceConstants.PACKAGE_STATUS_NEEDS_PAYMENT)
+      .into(new ArrayList<Document>());
+    
+    if ( packages.size() == 1 ) {
+      
+      Payment payment = confirmPaymentRequest.getPayment();
+      
+      boolean isAccountPayment = false;
+      if ( payment.getPaymentMethod().equalsIgnoreCase(FormServiceConstants.PAYMENT_TYPE_ACCOUNT) ) {
+        isAccountPayment = true;
+      }
+      
+      // If account payment, then obtain the account number from the presenter auth service
+      // The accountNumber submitted to here in confirmPaymentRequest is actually the presenter identifier 
+      // and not the account number used to make a charge from CHIPS
+      String presenterAccountNumber = null;
+      if ( isAccountPayment ) {
+        presenterAccountNumber = getPresenterAccountNumber(confirmPaymentRequest);
+      }
+      
+      //Find corresponding forms and update the payment information in each
+      ArrayList<Document> forms = helper.getFormsCollectionByPackageId(confirmPaymentRequest.getPackageIdentifier())
+              .into(new ArrayList<Document>());
+      for (Document form : forms) {
+        updateFormXmlAndStatus(form, payment, presenterAccountNumber);
+      }
+      
+      //Update package status
+      boolean result = MongoHelper.getInstance()
+              .updatePackageStatusByPackageId(confirmPaymentRequest.getPackageIdentifier(),
+                FormServiceConstants.PACKAGE_STATUS_DEFAULT);
+      if ( !result ) {
+        throw new DatabaseException("Failed to update database. Updating package status package id " 
+         + confirmPaymentRequest.getPackageIdentifier());
+      }
+
+    } else {
+      LoggingService.log(tag, INFO, "ConfirmPaymentRequest from Salesforce - no packages found: " + confirmPaymentRequest,
+        ConfirmPaymentResource.class);
+      throw new NoPackageFoundException(confirmPaymentRequest.getPackageIdentifier(), 
+        FormServiceConstants.PACKAGE_STATUS_NEEDS_PAYMENT);
+    }
+  }
+  
+  private String getPresenterAccountNumber(ConfirmPaymentRequest confirmPaymentRequest) throws PresenterAuthenticationException {
+    String presenterId = confirmPaymentRequest.getPayment().getAccountNumber();
+    String presenterAccountNumber = null;
+    if ( presenterId != null && !presenterId.isEmpty() ) {
+      PresenterAuthResponse presenterAuthResponse = presenterHelper.getPresenterResponse(presenterId, 
+        confirmPaymentRequest.getPayment().getAccountAuthCode());
+      presenterAccountNumber = presenterAuthResponse.getPresenterAccountNumber();
+      if ( presenterAccountNumber == null ) {
+        throw new PresenterAuthenticationException(presenterId, confirmPaymentRequest.getPayment().getAccountAuthCode());
+      }
+    }
+    return presenterAccountNumber;
+  }
+  
+  private void updateFormXmlAndStatus(Document form, Payment payment, String presenterAccountNumber) {
+    JSONObject jsonForm = new JSONObject(form.toJson());
+    String base64EncodedXml = jsonForm.getString(config.getXmlPropertyNameOut());
+    String unEncodedXml = new String(Base64.decodeBase64(base64EncodedXml));
+    
+    System.out.println(unEncodedXml);
+    System.out.println(presenterAccountNumber);
+    
+    unEncodedXml = unEncodedXml.replace(config.getReferenceNumberPlaceholderValueOut(), payment.getReferenceNumber());
+    unEncodedXml = unEncodedXml.replace(config.getPaymentMethodPlaceholderValueOut(), payment.getPaymentMethod());
+    unEncodedXml = unEncodedXml.replace(config.getAccountNumberPlaceholderValueOut(), payment.getAccountNumber());
+    
+    System.out.println(unEncodedXml);
+    
+    base64EncodedXml = new String(Base64.encodeBase64(unEncodedXml.getBytes()));
+    
+    //Update form xml
+    boolean result = MongoHelper.getInstance()
+            .updateFormXmlByObjectId(form.getObjectId(FormServiceConstants.DATABASE_OBJECTID_KEY), base64EncodedXml);
+    if ( !result ) {
+      throw new DatabaseException("Failed to update database while updating form xml for form id " 
+        + form.getObjectId(FormServiceConstants.DATABASE_OBJECTID_KEY));
+    }
+    
+    //Update form status
+    result = MongoHelper.getInstance()
+            .updateFormStatusByObjectId(form.getObjectId(FormServiceConstants.DATABASE_OBJECTID_KEY), 
+              FormServiceConstants.PACKAGE_STATUS_DEFAULT);
+    if ( !result ) {
+      throw new DatabaseException("Failed to update database while pdating form status for form id " 
+        + form.getObjectId(FormServiceConstants.DATABASE_OBJECTID_KEY));
+    }
+  }
+}

--- a/src/main/java/com/ch/helpers/ConfirmPaymentHelper.java
+++ b/src/main/java/com/ch/helpers/ConfirmPaymentHelper.java
@@ -60,7 +60,7 @@ public class ConfirmPaymentHelper {
         presenterAccountNumber = getPresenterAccountNumber(confirmPaymentRequest);
       }
       
-      //Find corresponding forms and update the payment information in each
+      //Find corresponding forms and update the payment information in each and the status
       ArrayList<Document> forms = helper.getFormsCollectionByPackageId(confirmPaymentRequest.getPackageIdentifier())
               .into(new ArrayList<Document>());
       for (Document form : forms) {
@@ -102,15 +102,10 @@ public class ConfirmPaymentHelper {
     JSONObject jsonForm = new JSONObject(form.toJson());
     String base64EncodedXml = jsonForm.getString(config.getXmlPropertyNameOut());
     String unEncodedXml = new String(Base64.decodeBase64(base64EncodedXml));
-    
-    System.out.println(unEncodedXml);
-    System.out.println(presenterAccountNumber);
-    
+
     unEncodedXml = unEncodedXml.replace(config.getReferenceNumberPlaceholderValueOut(), payment.getReferenceNumber());
     unEncodedXml = unEncodedXml.replace(config.getPaymentMethodPlaceholderValueOut(), payment.getPaymentMethod());
     unEncodedXml = unEncodedXml.replace(config.getAccountNumberPlaceholderValueOut(), payment.getAccountNumber());
-    
-    System.out.println(unEncodedXml);
     
     base64EncodedXml = new String(Base64.encodeBase64(unEncodedXml.getBytes()));
     

--- a/src/main/java/com/ch/helpers/MongoHelper.java
+++ b/src/main/java/com/ch/helpers/MongoHelper.java
@@ -292,16 +292,34 @@ public final class MongoHelper {
   }
 
   /**
-   * update matching form status by package Id.
+   * update matching form status by object Id.
    *
    * @return MongoCollection
    */
-  public boolean updateFormStatusByPackageId(ObjectId formId, String formStatus) {
+  public boolean updateFormStatusByObjectId(ObjectId formId, String formStatus) {
     MongoDatabase database = getDatabase();
 
     long modifiedCount = database.getCollection(configuration.getMongoDbFormsCollectionName()).updateMany(new Document(
       FormServiceConstants.DATABASE_OBJECTID_KEY, formId), new Document("$set", new Document(config.getFormStatusPropertyNameOut(),
       formStatus))).getModifiedCount();
+
+    if (modifiedCount == 1) {
+      return true;
+    }
+    return false;
+  }
+  
+  /**
+   * update matching form status by object Id.
+   *
+   * @return MongoCollection
+   */
+  public boolean updateFormXmlByObjectId(ObjectId formId, String xml) {
+    MongoDatabase database = getDatabase();
+
+    long modifiedCount = database.getCollection(configuration.getMongoDbFormsCollectionName()).updateMany(new Document(
+      FormServiceConstants.DATABASE_OBJECTID_KEY, formId), new Document("$set", new Document(config.getXmlPropertyNameOut(),
+      xml))).getModifiedCount();
 
     if (modifiedCount == 1) {
       return true;

--- a/src/main/java/com/ch/model/FormStatus.java
+++ b/src/main/java/com/ch/model/FormStatus.java
@@ -4,8 +4,8 @@ package com.ch.model;
  * Created by elliott.jenkins on 30/06/2016.
  */
 public enum FormStatus {
+  UNPAID,
   PENDING,
-  PAID,
   SUCCESS,
   FAILED
 }

--- a/src/main/java/com/ch/resources/ConfirmPaymentResource.java
+++ b/src/main/java/com/ch/resources/ConfirmPaymentResource.java
@@ -50,8 +50,8 @@ public class ConfirmPaymentResource {
   }
 
   /**
-   * Checks for existing packageReference with a status of PENDING and updates the payment information
-   * and the status to PAID.
+   * Checks for existing packageReference with a status of UNPAID and updates the payment information
+   * and the status to PENDING.
    *
    * @return response - 200 or 400
    */

--- a/src/main/resources/schemas/CORE.xsd
+++ b/src/main/resources/schemas/CORE.xsd
@@ -76,6 +76,7 @@
                 <xs:enumeration value="account"/>
                 <xs:enumeration value="creditcard"/>
                 <xs:enumeration value="prepaid"/>
+                <xs:enumeration value=":placeholderPaymentMethod:"/>
             </xs:restriction>
         </xs:simpleType>
     </xs:element>

--- a/src/test/java/com/ch/cucumber/ActivationSteps.java
+++ b/src/test/java/com/ch/cucumber/ActivationSteps.java
@@ -199,8 +199,8 @@ public class ActivationSteps extends TestHelper {
     ObjectId formOneId = formOne.getObjectId(FormServiceConstants.DATABASE_OBJECTID_KEY);
     ObjectId formTwoId = formTwo.getObjectId(FormServiceConstants.DATABASE_OBJECTID_KEY);
 
-    helper.updateFormStatusByPackageId(formOneId, FormStatus.FAILED.toString().toUpperCase());
-    helper.updateFormStatusByPackageId(formTwoId, FormStatus.FAILED.toString().toUpperCase());
+    helper.updateFormStatusByObjectId(formOneId, FormStatus.FAILED.toString().toUpperCase());
+    helper.updateFormStatusByObjectId(formTwoId, FormStatus.FAILED.toString().toUpperCase());
 
 
     //check the db contains two failed forms is failed

--- a/src/test/java/com/ch/helpers/MongoHelperTest.java
+++ b/src/test/java/com/ch/helpers/MongoHelperTest.java
@@ -84,7 +84,7 @@ public class MongoHelperTest extends TestHelper{
 
         helper.storeFormsPackage(formsPackage2);
 
-        ArrayList<Document> documents = helper.getPackagesCollectionByStatus(FormStatus.PENDING.toString()
+        ArrayList<Document> documents = helper.getPackagesCollectionByStatus(FormStatus.UNPAID.toString()
           .toUpperCase(Locale.ENGLISH), 2).into(new ArrayList<Document>());
         
         String packageIdentifier = documents.get(0).getString(config.getPackageIdentifierPropertyNameIn());
@@ -123,7 +123,7 @@ public class MongoHelperTest extends TestHelper{
 
         helper.storeFormsPackage(formsPackage2);
 
-        ArrayList<Document> documents = helper.getPackagesCollectionByStatus(FormStatus.PENDING.toString()
+        ArrayList<Document> documents = helper.getPackagesCollectionByStatus(FormStatus.UNPAID.toString()
           .toUpperCase(Locale.ENGLISH), 0).into(new ArrayList<Document>());
 
         Assert.assertTrue(documents.size() == 2);
@@ -158,7 +158,7 @@ public class MongoHelperTest extends TestHelper{
 
         helper.storeFormsPackage(formsPackage2);
 
-        ArrayList<Document> documents = helper.getPackagesCollectionByStatus(FormStatus.PENDING.toString()
+        ArrayList<Document> documents = helper.getPackagesCollectionByStatus(FormStatus.UNPAID.toString()
           .toUpperCase(Locale.ENGLISH), 1).into(new ArrayList<Document>());
 
         Assert.assertTrue(documents.size() == 1);

--- a/src/test/java/com/ch/helpers/QueueHelperTest.java
+++ b/src/test/java/com/ch/helpers/QueueHelperTest.java
@@ -78,7 +78,7 @@ public class QueueHelperTest extends TestHelper {
 
     QueueHelper queueHelper = new QueueHelper(config);
 
-    List<JSONObject> forms = queueHelper.getCompletePackagesByStatus(FormStatus.PENDING.toString().toUpperCase(Locale.ENGLISH),1);
+    List<JSONObject> forms = queueHelper.getCompletePackagesByStatus(FormStatus.UNPAID.toString().toUpperCase(Locale.ENGLISH),1);
 
     Assert.assertTrue(forms.size() == 1);
     Assert.assertTrue(forms.get(0).getInt(config.getPackageCountPropertyNameIn()) == 5);


### PR DESCRIPTION
Adds the actual functionality to update the form xml with payment details and also the status of the forms and package.  Paid forms and packages have a status of UNPAID when submitted to the gateway and the confirmpayment end point sets this to PENDING so they get sent to CHIPS.

Unit tests are still outstanding, but this PR is being raised now so that integration/development on Salesforce can continue in parallel. 

SUP-309