### PR TITLE
Upgrade checkstyle to fix security vulnerabilities

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -31,10 +31,9 @@
     <module name="FileTabCharacter">
         <property name="eachLine" value="true"/>
     </module>
-    <module name="SuppressionCommentFilter"/>
     <module name="SuppressWarningsFilter"/>
     <module name="TreeWalker">
-        <module name="FileContentsHolder"/>
+        <module name="SuppressionCommentFilter"/>
         <module name="SuppressWarningsHolder"/>
         <module name="OuterTypeFilename"/>
         <module name="IllegalTokenText">
@@ -74,9 +73,7 @@
                       value="LITERAL_TRY, LITERAL_FINALLY, LITERAL_IF, LITERAL_ELSE, LITERAL_SWITCH"/>
         </module>
         <module name="NeedBraces"/>
-        <module name="LeftCurly">
-            <property name="maxLineLength" value="100"/>
-        </module>
+        <module name="LeftCurly"/>
         <module name="RightCurly"/>
         <module name="RightCurly">
             <property name="option" value="alone"/>

--- a/pom.xml
+++ b/pom.xml
@@ -233,12 +233,12 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-checkstyle-plugin</artifactId>
-                <version>2.15</version>
+                <version>3.1.0</version>
                 <dependencies>
                     <dependency>
                         <groupId>com.puppycrawl.tools</groupId>
                         <artifactId>checkstyle</artifactId>
-                        <version>6.14</version>
+                        <version>8.18</version>
                     </dependency>
                 </dependencies>
                 <executions>

--- a/src/main/java/com/ch/conversion/builders/FormJsonBuilder.java
+++ b/src/main/java/com/ch/conversion/builders/FormJsonBuilder.java
@@ -10,9 +10,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-/**
- * Created by elliott.jenkins on 31/03/2016.
- */
 public class FormJsonBuilder {
 
   private final JsonHelper helper;
@@ -112,7 +109,7 @@ public class FormJsonBuilder {
   }
 
   /**
-   * Adds submission reference to json object
+   * Adds submission reference to json object.
    *
    * @param submissionReference as string.
    * @return Form as JSONObject.

--- a/src/main/java/com/ch/conversion/transformations/MetaDataTransform.java
+++ b/src/main/java/com/ch/conversion/transformations/MetaDataTransform.java
@@ -1,6 +1,5 @@
 package com.ch.conversion.transformations;
 
-
 import com.ch.conversion.config.ITransformConfig;
 import com.ch.conversion.helpers.XmlHelper;
 import org.json.JSONObject;

--- a/src/main/java/com/ch/conversion/validation/XmlValidatorImpl.java
+++ b/src/main/java/com/ch/conversion/validation/XmlValidatorImpl.java
@@ -1,6 +1,5 @@
 package com.ch.conversion.validation;
 
-
 import com.ch.conversion.config.ITransformConfig;
 import com.ch.conversion.helpers.XmlHelper;
 import com.ch.exception.XsdValidationException;

--- a/src/main/java/com/ch/model/FormsPackage.java
+++ b/src/main/java/com/ch/model/FormsPackage.java
@@ -1,6 +1,5 @@
 package com.ch.model;
 
-
 import org.json.JSONObject;
 
 import java.util.ArrayList;

--- a/src/main/java/com/ch/service/LoggingService.java
+++ b/src/main/java/com/ch/service/LoggingService.java
@@ -5,9 +5,6 @@ import org.apache.log4j.LogManager;
 import org.apache.log4j.Logger;
 import org.fluentd.logger.FluentLogger;
 
-/**
- * Created by elliott.jenkins on 19/05/2016.
- */
 @SuppressWarnings("PMD")
 public class LoggingService {
 
@@ -29,7 +26,7 @@ public class LoggingService {
 
   /**
    * Logs key/value pair as JSON into FluentD instance using the tag as a matcher, if FluentLogger is off the
-   * object value is logged via log4j
+   * object value is logged via log4j.
    *
    * @param tag   string which is used as matcher category in FluentD
    * @param level used as a JSON key in FluentD


### PR DESCRIPTION
Upgrade the version of checkstyle to fix [security vulnerabilities](https://github.com/companieshouse/forms-enablement-api/network/alert/pom.xml/com.puppycrawl.tools:checkstyle/open). Upgrade Maven checkstyle plugin to fix compatibility issues with new checkstyle version.

Changes to the checkstyle configuration:
1. SuppressionCommentFilter must now be a child of TreeWalker
2. FileContentsHolder has been removed
3. maxLineLength for LeftCurly has been removed

Fix issues raised by the checkstyle analysis causing build failure:
1. Additional empty line when separating imports from package name
2. Missing full stop at end of JavaDoc message.